### PR TITLE
Nonblocking comms

### DIFF
--- a/custom_components/rinnaitouch/__init__.py
+++ b/custom_components/rinnaitouch/__init__.py
@@ -12,7 +12,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.const import Platform
 from homeassistant.helpers.device_registry import DeviceEntry
 
-from .pyrinnaitouch import RinnaiSystem
+from pyrinnaitouch import RinnaiSystem
 
 from .const import DOMAIN
 

--- a/custom_components/rinnaitouch/__init__.py
+++ b/custom_components/rinnaitouch/__init__.py
@@ -1,4 +1,5 @@
 """Set up main entity."""
+
 # pylint: disable=duplicate-code
 import logging
 from dataclasses import dataclass
@@ -11,7 +12,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.const import Platform
 from homeassistant.helpers.device_registry import DeviceEntry
 
-from pyrinnaitouch import RinnaiSystem
+from .pyrinnaitouch import RinnaiSystem
 
 from .const import DOMAIN
 
@@ -32,7 +33,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     ip_address = entry.data.get(CONF_HOST)
     _LOGGER.debug("Get controller with IP: %s", ip_address)
-
+    _LOGGER.error("Ok initing rinnaitouch now")
     try:
         system: RinnaiSystem = RinnaiSystem.get_instance(ip_address)
         # scenes = await system.getSupportedScenes()
@@ -44,7 +45,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         ConnectionError,
         ConnectionRefusedError,
     ) as err:
-        _LOGGER.debug("Get controller error: %s", err)
+        _LOGGER.error("Get controller error: %s", err)
         raise ConfigEntryNotReady from err
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = RinnaiData(

--- a/custom_components/rinnaitouch/__init__.py
+++ b/custom_components/rinnaitouch/__init__.py
@@ -63,6 +63,10 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         hass.data[DOMAIN].pop(entry.entry_id)
+
+    RinnaiSystem.remove_instance(ip_address)
+    _LOGGER.debug("Controller with IP: %s removed", ip_address)
+
     return unload_ok
 
 

--- a/custom_components/rinnaitouch/__init__.py
+++ b/custom_components/rinnaitouch/__init__.py
@@ -33,7 +33,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     ip_address = entry.data.get(CONF_HOST)
     _LOGGER.debug("Get controller with IP: %s", ip_address)
-    _LOGGER.error("Ok initing rinnaitouch now")
     try:
         system: RinnaiSystem = RinnaiSystem.get_instance(ip_address)
         # scenes = await system.getSupportedScenes()

--- a/custom_components/rinnaitouch/binary_sensor.py
+++ b/custom_components/rinnaitouch/binary_sensor.py
@@ -516,7 +516,7 @@ class RinnaiConnectedBinarySensorEntity(RinnaiBinarySensorEntity):
             # Enum value 3 is CONNECTED, but use name for clarity
             self._connected = getattr(state, "name", None) == "CONNECTED"
             self.schedule_update_ha_state()
-        except Exception:
+        except Exception:  # pylint: disable=broad-except
             pass
 
     @property

--- a/custom_components/rinnaitouch/climate.py
+++ b/custom_components/rinnaitouch/climate.py
@@ -66,7 +66,7 @@ from .const import (
     PRESET_MANUAL,
     SET_DATETIME,
 )
-from .pyrinnaitouch import (
+from pyrinnaitouch import (
     TEMP_FAHRENHEIT,
     RinnaiCapabilities,
     RinnaiOperatingMode,
@@ -77,15 +77,15 @@ from .pyrinnaitouch import (
 
 SUPPORT_FLAGS_MAIN = (
     ClimateEntityFeature.TARGET_TEMPERATURE
-        | ClimateEntityFeature.PRESET_MODE
-        | ClimateEntityFeature.TURN_OFF
-        | ClimateEntityFeature.TURN_ON
+    | ClimateEntityFeature.PRESET_MODE
+    | ClimateEntityFeature.TURN_OFF
+    | ClimateEntityFeature.TURN_ON
 )
 SUPPORT_FLAGS_ZONE = (
     ClimateEntityFeature.TARGET_TEMPERATURE
-        | ClimateEntityFeature.PRESET_MODE
-        | ClimateEntityFeature.TURN_OFF
-        | ClimateEntityFeature.TURN_ON
+    | ClimateEntityFeature.PRESET_MODE
+    | ClimateEntityFeature.TURN_OFF
+    | ClimateEntityFeature.TURN_ON
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/rinnaitouch/climate.py
+++ b/custom_components/rinnaitouch/climate.py
@@ -46,6 +46,15 @@ from homeassistant.helpers import (
 )
 from homeassistant.helpers.entity_registry import async_entries_for_device
 
+from pyrinnaitouch import (
+    TEMP_FAHRENHEIT,
+    RinnaiCapabilities,
+    RinnaiOperatingMode,
+    RinnaiSystem,
+    RinnaiSystemMode,
+    RinnaiSystemStatus,
+)
+
 from .const import (
     CONF_TEMP_SENSOR,
     CONF_TEMP_SENSOR_A,
@@ -66,14 +75,7 @@ from .const import (
     PRESET_MANUAL,
     SET_DATETIME,
 )
-from pyrinnaitouch import (
-    TEMP_FAHRENHEIT,
-    RinnaiCapabilities,
-    RinnaiOperatingMode,
-    RinnaiSystem,
-    RinnaiSystemMode,
-    RinnaiSystemStatus,
-)
+
 
 SUPPORT_FLAGS_MAIN = (
     ClimateEntityFeature.TARGET_TEMPERATURE

--- a/custom_components/rinnaitouch/climate.py
+++ b/custom_components/rinnaitouch/climate.py
@@ -19,59 +19,73 @@ COOLING_COOL -> Refrigerated mode
 # pylint: disable=too-many-lines
 
 from __future__ import annotations
-import asyncio
-from datetime import timedelta, datetime
 
+import asyncio
+from datetime import datetime, timedelta
 import logging
 
-from pyrinnaitouch import (
-    RinnaiSystem,
-    RinnaiSystemMode,
-    TEMP_FAHRENHEIT,
-    RinnaiCapabilities,
-    RinnaiOperatingMode,
-    RinnaiSystemStatus,
-)
-
-from homeassistant.components.climate import ClimateEntity
-from homeassistant.components.climate import HVACMode, HVACAction, ClimateEntityFeature
-from homeassistant.const import (
-    CONF_NAME,
-    CONF_HOST,
-    UnitOfTemperature,
-    ATTR_TEMPERATURE,
-)
-from homeassistant.helpers import device_registry as dr, entity_registry as er
-from homeassistant.helpers.entity_registry import async_entries_for_device
-from homeassistant.helpers import config_validation as cv, entity_platform
 import voluptuous as vol
 
+from homeassistant.components.climate import (
+    ClimateEntity,
+    ClimateEntityFeature,
+    HVACAction,
+    HVACMode,
+)
+from homeassistant.const import (
+    ATTR_TEMPERATURE,
+    CONF_HOST,
+    CONF_NAME,
+    UnitOfTemperature,
+)
+from homeassistant.helpers import (
+    config_validation as cv,
+    device_registry as dr,
+    entity_platform,
+    entity_registry as er,
+)
+from homeassistant.helpers.entity_registry import async_entries_for_device
+
 from .const import (
-    PRESET_AUTO,
-    PRESET_MANUAL,
-    COOLING_EVAP,
-    COOLING_COOL,
-    COOLING_NONE,
     CONF_TEMP_SENSOR,
     CONF_TEMP_SENSOR_A,
     CONF_TEMP_SENSOR_B,
     CONF_TEMP_SENSOR_C,
-    CONF_TEMP_SENSOR_D,
     CONF_TEMP_SENSOR_COMMON,
+    CONF_TEMP_SENSOR_D,
     CONF_ZONE_A,
     CONF_ZONE_B,
     CONF_ZONE_C,
-    CONF_ZONE_D,
     CONF_ZONE_COMMON,
+    CONF_ZONE_D,
+    COOLING_COOL,
+    COOLING_EVAP,
+    COOLING_NONE,
     DEFAULT_NAME,
+    PRESET_AUTO,
+    PRESET_MANUAL,
     SET_DATETIME,
+)
+from .pyrinnaitouch import (
+    TEMP_FAHRENHEIT,
+    RinnaiCapabilities,
+    RinnaiOperatingMode,
+    RinnaiSystem,
+    RinnaiSystemMode,
+    RinnaiSystemStatus,
 )
 
 SUPPORT_FLAGS_MAIN = (
-    ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.PRESET_MODE
+    ClimateEntityFeature.TARGET_TEMPERATURE
+    | ClimateEntityFeature.PRESET_MODE
+    | ClimateEntityFeature.TURN_ON
+    | ClimateEntityFeature.TURN_OFF
 )
 SUPPORT_FLAGS_ZONE = (
-    ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.PRESET_MODE
+    ClimateEntityFeature.TARGET_TEMPERATURE
+    | ClimateEntityFeature.PRESET_MODE
+    | ClimateEntityFeature.TURN_ON
+    | ClimateEntityFeature.TURN_OFF
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -120,7 +134,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
         {
             vol.Optional(SET_DATETIME): cv.datetime,
         },
-        "set_system_time"
+        "set_system_time",
     )
     return True
 

--- a/custom_components/rinnaitouch/manifest.json
+++ b/custom_components/rinnaitouch/manifest.json
@@ -4,8 +4,8 @@
   "documentation": "https://github.com/funtastix/rinnaitouch",
   "issue_tracker": "https://github.com/funtastix/rinnaitouch/issues",
   "codeowners": [ "@funtastix" ],
-  "requirements": [ "pyrinnaitouch>=0.12.14" ],
+  "requirements": [ "pyrinnaitouch>=0.13.0" ],
   "config_flow": true,
-  "version": "0.12.15",
+  "version": "0.13.0",
   "iot_class": "local_push"
 }

--- a/custom_components/rinnaitouch/requirements.txt
+++ b/custom_components/rinnaitouch/requirements.txt
@@ -1,4 +1,4 @@
 async_timeout>=3.0.1
 asyncio>=3.4.3
-pyrinnaitouch>=0.12.14
+#pyrinnaitouch>=0.12.14
 homeassistant>=2024.2.0

--- a/custom_components/rinnaitouch/requirements.txt
+++ b/custom_components/rinnaitouch/requirements.txt
@@ -1,4 +1,4 @@
 async_timeout>=3.0.1
 asyncio>=3.4.3
-#pyrinnaitouch>=0.12.14
+pyrinnaitouch>=0.13.0
 homeassistant>=2024.2.0

--- a/custom_components/rinnaitouch/sensor.py
+++ b/custom_components/rinnaitouch/sensor.py
@@ -375,7 +375,7 @@ class RinnaiConnectionStateSensor(SensorEntity):
         try:
             self._connection_state = getattr(state, "name", str(state))
             self.schedule_update_ha_state()
-        except Exception:
+        except Exception:  # pylint: disable=broad-except
             pass
 
     @property

--- a/custom_components/rinnaitouch/switch.py
+++ b/custom_components/rinnaitouch/switch.py
@@ -22,12 +22,8 @@ from .const import (
     DEFAULT_NAME,
 )
 
-# _LOGGER = logging.getLogger(__name__)
 
-
-async def async_setup_entry(
-    hass, entry, async_add_entities
-):  # pylint: disable=unused-argument
+async def async_setup_entry(hass, entry, async_add_entities):  # pylint: disable=unused-argument
     """Set up the switch entities."""
     ip_address = entry.data.get(CONF_HOST)
     name = entry.data.get(CONF_NAME)
@@ -473,9 +469,7 @@ class RinnaiCircFanSwitch(RinnaiExtraEntity, SwitchEntity):
     @property
     def available(self):
         state: RinnaiSystemStatus = self._system.get_stored_status()
-        if not (
-            state.mode in (RinnaiSystemMode.COOLING, RinnaiSystemMode.HEATING)
-        ):  # pylint: disable=superfluous-parens
+        if not (state.mode in (RinnaiSystemMode.COOLING, RinnaiSystemMode.HEATING)):  # pylint: disable=superfluous-parens
             return False
         if not state.system_on:
             return True


### PR DESCRIPTION
Here is the HA component update that goes along with the pyrinnaitouch non-blocking comms update. It adds a new binary sensor to indicate when we are connected to the unit, and a connection state sensor for determining when to reset the unit. My recommendation would be that if it stays in the "REFUSED" state for more than a few minutes, a reset is due.

Created as drafts for now for people to look over, since I'm only able to test very limited situations on my own.